### PR TITLE
Support for RFC1123Z

### DIFF
--- a/pcd.go
+++ b/pcd.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/kvannotten/pcd/rss"
 	"github.com/pkg/errors"
@@ -33,7 +32,7 @@ type Podcast struct {
 
 type Episode struct {
 	Title  string
-	Date   time.Time
+	Date   string
 	URL    string
 	Length int
 }
@@ -158,7 +157,7 @@ func (p *Podcast) String() string {
 			title = fmt.Sprintf("%s...", episode.Title[0:(titleLength-4)])
 		}
 		formatStr := fmt.Sprintf("%%-4d %%-%ds %%20s\n", tl)
-		sb.WriteString(fmt.Sprintf(formatStr, index+1, title, episode.Date.Format(rss.Layout)))
+		sb.WriteString(fmt.Sprintf(formatStr, index+1, title, episode.Date))
 	}
 
 	return sb.String()
@@ -217,14 +216,10 @@ func parseEpisodes(content io.Reader) ([]Episode, error) {
 	var episodes []Episode
 
 	for _, item := range feed.Channel.Items {
-		t, err := time.Parse(rss.Layout, item.Date.Date)
-		if err != nil {
-			log.Printf("Could not parse episode: %#v", err)
-			continue
-		}
+
 		episode := Episode{
 			Title:  item.Title.Title,
-			Date:   t,
+			Date:   item.Date.Date,
 			URL:    item.Enclosure.URL,
 			Length: item.Enclosure.Length,
 		}

--- a/pcd_test.go
+++ b/pcd_test.go
@@ -9,9 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/kvannotten/pcd/rss"
 )
 
 func TestSync(t *testing.T) {
@@ -130,7 +127,7 @@ func TestEpisodes(t *testing.T) {
 }
 
 func TestPodcastString(t *testing.T) {
-	now := time.Now()
+	now := "Thu, 10 Nov 2016 19:41:48 -0700"
 
 	podcast := &Podcast{
 		Name:     "test",
@@ -143,7 +140,7 @@ func TestPodcastString(t *testing.T) {
 	if !strings.Contains(podcast.String(), podcast.Episodes[0].Title) {
 		t.Error("Expected episode title to be in the output")
 	}
-	if !strings.Contains(podcast.String(), now.Format(rss.Layout)) {
+	if !strings.Contains(podcast.String(), podcast.Episodes[0].Date) {
 		t.Error("Expected date to be in the output")
 	}
 

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"strings"
 	"testing"
-	"time"
 )
 
 var podcastfeed = `<?xml version="1.0" encoding="UTF-8"?>
@@ -104,6 +103,102 @@ var podcastfeedReversed = `<?xml version="1.0" encoding="UTF-8"?>
 </channel>
 </rss>`
 
+var podcastfeedMixed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+<channel>
+<title>Title of Podcast</title>
+<link>http://www.example.com/</link>
+<language>en-us</language>
+<itunes:subtitle>Subtitle of podcast</itunes:subtitle>
+<itunes:author>Author Name</itunes:author>
+<itunes:summary>Description of podcast.</itunes:summary>
+<description>Description of podcast.</description>
+<itunes:owner>
+    <itunes:name>Owner Name</itunes:name>
+    <itunes:email>me@example.com</itunes:email>
+</itunes:owner>
+<itunes:explicit>no</itunes:explicit>
+<itunes:image href="http://www.example.com/podcast-icon.jpg" />
+<itunes:category text="Category Name"></itunes:category>
+
+<!--REPEAT THIS BLOCK FOR EACH EPISODE-->
+<item>
+    <title>Title of Podcast Episode 2</title>
+    <itunes:summary>Description of podcast episode content</itunes:summary>
+    <description>Description of podcast episode content</description>
+    <link>http://example.com/podcast-1</link>
+    <enclosure url="http://example.com/podcast-1/podcast.mp3" type="audio/mpeg" length="1024"></enclosure>
+    <pubDate>Thu, 29 Dec 2016 16:01:07 +0000</pubDate>
+    <itunes:author>Author Name</itunes:author>
+    <itunes:duration>00:32:16</itunes:duration>
+    <itunes:explicit>no</itunes:explicit>
+    <guid>http://example.com/podcast-1</guid>
+</item> 
+<item>
+    <title>Title of Podcast Episode</title>
+    <itunes:summary>Description of podcast episode content</itunes:summary>
+    <description>Description of podcast episode content</description>
+    <link>http://example.com/podcast-1</link>
+    <enclosure url="http://example.com/podcast-1/podcast.mp3" type="audio/mpeg" length="1024"></enclosure>
+    <pubDate>Thu, 21 Dec 2016 16:01:07 +0000</pubDate>
+    <itunes:author>Author Name</itunes:author>
+    <itunes:duration>00:32:16</itunes:duration>
+    <itunes:explicit>no</itunes:explicit>
+    <guid>http://example.com/podcast-1</guid>
+</item> 
+<item>
+    <title>Title of Podcast Episode 3</title>
+    <itunes:summary>Description of podcast episode content</itunes:summary>
+    <description>Description of podcast episode content</description>
+    <link>http://example.com/podcast-1</link>
+    <enclosure url="http://example.com/podcast-1/podcast.mp3" type="audio/mpeg" length="1024"></enclosure>
+    <pubDate>Wed, 11 Jan 2017 16:01:07 +0000</pubDate>
+    <itunes:author>Author Name</itunes:author>
+    <itunes:duration>00:32:16</itunes:duration>
+    <itunes:explicit>no</itunes:explicit>
+    <guid>http://example.com/podcast-1</guid>
+</item> 
+<!--END REPEAT--> 
+   
+</channel>
+</rss>`
+
+var podcastfeedRFC1123Z = `<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+<channel>
+<title>Title of Podcast</title>
+<link>http://www.example.com/</link>
+<language>en-us</language>
+<itunes:subtitle>Subtitle of podcast</itunes:subtitle>
+<itunes:author>Author Name</itunes:author>
+<itunes:summary>Description of podcast.</itunes:summary>
+<description>Description of podcast.</description>
+<itunes:owner>
+    <itunes:name>Owner Name</itunes:name>
+    <itunes:email>me@example.com</itunes:email>
+</itunes:owner>
+<itunes:explicit>no</itunes:explicit>
+<itunes:image href="http://www.example.com/podcast-icon.jpg" />
+<itunes:category text="Category Name"></itunes:category>
+
+<!--REPEAT THIS BLOCK FOR EACH EPISODE-->
+<item>
+    <title>Title of Podcast Episode</title>
+    <itunes:summary>Description of podcast episode content</itunes:summary>
+    <description>Description of podcast episode content</description>
+    <link>http://example.com/podcast-1</link>
+    <enclosure url="http://example.com/podcast-1/podcast.mp3" type="audio/mpeg" length="1024"></enclosure>
+    <pubDate>Thu, 21 Dec 2016 16:01:07 GMT</pubDate>
+    <itunes:author>Author Name</itunes:author>
+    <itunes:duration>00:32:16</itunes:duration>
+    <itunes:explicit>no</itunes:explicit>
+    <guid>http://example.com/podcast-1</guid>
+</item> 
+<!--END REPEAT--> 
+   
+</channel>
+</rss>`
+
 func TestParse(t *testing.T) {
 	feed, err := Parse(strings.NewReader(podcastfeed))
 	if err != nil {
@@ -156,6 +251,32 @@ func TestInvalidContentParse(t *testing.T) {
 	}
 }
 
+func TestParseRFC1123Z(t *testing.T) {
+	feed, err := Parse(strings.NewReader(podcastfeedRFC1123Z))
+	if err != nil {
+		t.Errorf("Did not expect error but got: %#v", err)
+	}
+
+	table := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"podcast title", feed.Channel.Title.Title, "Title of Podcast"},
+		{"podcast description", feed.Channel.Description.Description, "Description of podcast."},
+		{"title of item", feed.Channel.Items[0].Title.Title, "Title of Podcast Episode"},
+		{"publication date", feed.Channel.Items[0].Date.Date, "Thu, 21 Dec 2016 16:01:07 GMT"},
+	}
+
+	for _, e := range table {
+		t.Run(e.name, func(t *testing.T) {
+			if e.got != e.want {
+				t.Errorf("Expected %s, got: %s", e.want, e.got)
+			}
+		})
+	}
+}
+
 func TestSort(t *testing.T) {
 	feed1, err := Parse(strings.NewReader(podcastfeed))
 	if err != nil {
@@ -165,27 +286,37 @@ func TestSort(t *testing.T) {
 	if err != nil {
 		t.Errorf("Didn't expect error but got: %#v", err)
 	}
+	feed3, err := Parse(strings.NewReader(podcastfeedMixed))
+	if err != nil {
+		t.Errorf("Didn't expect error but got: %#v", err)
+	}
 
-	if feed1.Channel.Items[0].Title.Title != feed2.Channel.Items[0].Title.Title {
+	title1 := feed1.Channel.Items[0].Title.Title
+	title2 := feed2.Channel.Items[0].Title.Title
+	title3 := feed3.Channel.Items[0].Title.Title
+
+	if title1 != title2 && title1 != title3 {
 		t.Errorf("Expected title to be the same after ordering, but it wasn't")
 	}
 
-	expectedDate, _ := time.Parse(Layout, "Thu, 21 Dec 2016 16:01:07 +0000")
-	feed1Time, _ := time.Parse(Layout, feed1.Channel.Items[0].Date.Date)
-	feed2Time, _ := time.Parse(Layout, feed2.Channel.Items[0].Date.Date)
+	expectedDate := "Thu, 21 Dec 2016 16:01:07 +0000"
+	feed1Time := feed1.Channel.Items[0].Date.Date
+	feed2Time := feed2.Channel.Items[0].Date.Date
+	feed3Time := feed3.Channel.Items[0].Date.Date
 
 	table := []struct {
 		name string
-		got  time.Time
-		want time.Time
+		got  string
+		want string
 	}{
 		{"time should be early to later for feed1", feed1Time, expectedDate},
 		{"time should be early to later for feed2", feed2Time, expectedDate},
+		{"time should be early to later for feed3", feed3Time, expectedDate},
 	}
 	for _, e := range table {
 		t.Run(e.name, func(t *testing.T) {
-			if e.got.Sub(e.want) > 1*time.Millisecond {
-				t.Errorf("Expected ordering from early to later, got %#v, want: %#v", e.got.Format(Layout), e.want.Format(Layout))
+			if e.got != e.want {
+				t.Errorf("Expected ordering from early to later, got %#v, want: %#v", e.got, e.want)
 			}
 		})
 	}


### PR DESCRIPTION
Podcast feeds can have multiple date formats under the pubDate node.
Add support for RFC1123Z, ie MST instead of -0700 in the time.Parse format.
This is not exhaustive lookup as there is no 'standard' apparently.

Fix #3