### PR TITLE
Generate filename as URL Path's base name

### DIFF
--- a/pcd.go
+++ b/pcd.go
@@ -174,6 +174,10 @@ func (e *Episode) Download(path string, writer io.Writer) error {
 		return ErrCouldNotDownload
 	}
 
+	if u.Path == "" {
+		return ErrFilesystemError
+	}
+
 	filename := urlpath.Base(u.Path)
 	fpath := filepath.Join(path, filename)
 

--- a/pcd.go
+++ b/pcd.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
+	urlpath "path"
 	"path/filepath"
 	"strings"
 
@@ -166,8 +168,13 @@ func (p *Podcast) String() string {
 // Download downloads an episode in 'path'. The writer argument is optional
 // and will just mirror everything written into it (useful for tracking the speed)
 func (e *Episode) Download(path string, writer io.Writer) error {
-	tokens := strings.Split(e.URL, "/")
-	filename := tokens[len(tokens)-1]
+	u, err := url.Parse(e.URL)
+	if err != nil {
+		log.Printf("Parse episode url failed: %#v", err)
+		return ErrCouldNotDownload
+	}
+
+	filename := urlpath.Base(u.Path)
 	fpath := filepath.Join(path, filename)
 
 	if _, err := os.Stat(fpath); !os.IsNotExist(err) {

--- a/pcd_test.go
+++ b/pcd_test.go
@@ -216,7 +216,7 @@ func TestDownload(t *testing.T) {
 
 	episode := episodes[0]
 	ts := testServer()
-	episode.URL = ts.URL
+	episode.URL = ts.URL + "/sample.mp3"
 
 	if err := episode.Download(randomPath(t), nil); err != nil {
 		t.Errorf("Expected to be able to download episode, but got: %#v", err)
@@ -232,7 +232,7 @@ func TestInvalidDownload(t *testing.T) {
 		err     error
 	}{
 		{"invalid url", &Episode{URL: "invalid"}, randomPath(t), nil, ErrCouldNotDownload},
-		{"invalid status", &Episode{URL: testServerWithStatusCode(404).URL}, randomPath(t), nil, ErrCouldNotDownload},
+		{"invalid status", &Episode{URL: testServerWithStatusCode(404).URL + "/sample.mp3"}, randomPath(t), nil, ErrCouldNotDownload},
 		{"invalid path", &Episode{URL: testServer().URL}, "/root/access", nil, ErrFilesystemError},
 	}
 


### PR DESCRIPTION
The episode's URL may have query parameters, such as
`<host>/<filename.mp3>?dest-id=24990`,
which is invalid for file path to write into.

Such as podcast rss for this URL: http://devopscafe.libsyn.com/rss