### PR TITLE
Add ID to the ls output

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -48,7 +48,7 @@ var listCmd = &cobra.Command{
 				if err := podcast.Load(); err != nil {
 					log.Fatalf("Could not load podcast: %#v", err)
 				}
-				fmt.Printf("\t- %-40s (%d episodes)\n", podcast.Name, len(podcast.Episodes))
+                                fmt.Printf("\t%d - %-40s (%d episodes)\n", podcast.ID, podcast.Name, len(podcast.Episodes))
 			}
 		}
 	},


### PR DESCRIPTION
I like to have full length names for the shows in my list and it's much easier to use the `ID` for `download` and `list` behaviors. Rather than read the config YAML every time it makes sense to include ID in the `ls` output.