### PR TITLE
Partial Show Name Match

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -48,7 +48,7 @@ var listCmd = &cobra.Command{
 				if err := podcast.Load(); err != nil {
 					log.Fatalf("Could not load podcast: %#v", err)
 				}
-				fmt.Printf("\t- %-40s (%d episodes)\n", podcast.Name, len(podcast.Episodes))
+                                fmt.Printf("\t%d - %-40s (%d episodes)\n", podcast.ID, podcast.Name, len(podcast.Episodes))
 			}
 		}
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -131,7 +131,6 @@ func findByFunc(fn func(podcast *pcd.Podcast) bool) *pcd.Podcast {
                     matchedPodcasts = append(matchedPodcasts, &matchedPodcast)
 		}
 	}
-        log.Print(matchedPodcasts)
         if len(matchedPodcasts) == 1 {
 		return matchedPodcasts[0]
         } else {

--- a/pcd.go
+++ b/pcd.go
@@ -51,7 +51,6 @@ type Episode struct {
 	Title  string
 	Date   string
 	URL    string
-	Length int
 }
 
 var (
@@ -247,7 +246,6 @@ func parseEpisodes(content io.Reader) ([]Episode, error) {
 			Title:  item.Title.Title,
 			Date:   item.Date.Date,
 			URL:    item.Enclosure.URL,
-			Length: item.Enclosure.Length,
 		}
 
 		episodes = append(episodes, episode)

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -67,7 +67,6 @@ type ItemLink struct {
 type Enclosure struct {
 	XMLName xml.Name `xml:"enclosure"`
 	URL     string   `xml:"url,attr"`
-	Length  int      `xml:"length,attr"`
 	Type    string   `xml:"type,attr"`
 }
 


### PR DESCRIPTION
If you use full show names instead of the snake case examples in the README it's more difficult to get a match when trying to use a show name instead of an ID as the identifier in `ls` and `d` calls. This allows a partial show name match to return the show and logs the specifics of the matched shows if the request is not specific enough.